### PR TITLE
Scan song

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,7 +76,6 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop playing the current song",
 	Long:  `Stop playing the current song using the os signal.`,
-	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		err := player.Stop()
 		if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,9 +22,9 @@ var rootCmd = &cobra.Command{
 }
 
 var cmdScan = &cobra.Command{
-	Use:   "scan",
-	Short: "Scan for videos",
-	Long:  `Scan the directory specified for music mp3 files.`,
+	Use:   "menu",
+	Short: "Display information for all songs in the directory.",
+	Long:  `Scan the directory specified for the information of all the songs in the directory.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Access configuration for directory
 		songs, err := scanner.GetAllSongs(config.MusicDir)
@@ -37,6 +37,25 @@ var cmdScan = &cobra.Command{
 		fmt.Printf("Found %d song(s):\n", len(songs))
 		for _, song := range songs {
 			fmt.Println(song.SongMetadata.Title, " - ", song.FilePath)
+		}
+	},
+}
+
+var cmdList = &cobra.Command{
+	Use:   "list",
+	Short: "List all songs in the directory.",
+	Long:  `Scan the directory specified for music mp3 files and list them.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Access configuration for directory
+		songs, err := scanner.GetAllSongs(config.MusicDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error scanning for songs in %s: %v\n", config.MusicDir, err)
+			os.Exit(1)
+		}
+
+		// Print the songs filePath as a list
+		for _, song := range songs {
+			fmt.Println(song.FilePath)
 		}
 	},
 }
@@ -91,6 +110,7 @@ func main() {
 	rootCmd.AddCommand(cmdDownload)
 	rootCmd.AddCommand(playCmd)
 	rootCmd.AddCommand(stopCmd)
+	rootCmd.AddCommand(cmdList)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 )
 
 func ScanFiles(dirToScan string, extension string) (files []string, err error) {
@@ -46,10 +47,14 @@ func ReadJSONMetadata(metadataFiles []string) ([]SongInfo, error) {
 			return nil, err
 		}
 
+		// Get the corresponding mp3 file
+		// mp3 file path is saved alongside the metadata file with the same name
+		mp3FilePath := strings.TrimSuffix(file, ".info.json") + ".mp3"
+
 		// Create SongInfo from SongMetadata
 		info := SongInfo{
 			SongMetadata: metadata,
-			FilePath:     file,
+			FilePath:     mp3FilePath,
 		}
 
 		songInfo = append(songInfo, info)


### PR DESCRIPTION
### Features
- Refactor command line option: add more option `list` and `menu`. Option `scan` is removed.
- Scanner output mp3 path instead of metadata path.